### PR TITLE
Fix homebrew python-config reference

### DIFF
--- a/Formula/med-file.rb
+++ b/Formula/med-file.rb
@@ -36,7 +36,9 @@ class MedFile < Formula
     cmake_args << "-DMEDFILE_INSTALL_DOC:BOOL=OFF"    if build.without? "docs"
 
     if build.with? "python"
-      python_prefix=`#{HOMEBREW_PREFIX}/bin/python-config --prefix`.chomp
+      python = Formula["python"]
+      python_major = python.version.to_s.split(/\./,2).first
+      python_prefix=`#{HOMEBREW_PREFIX}/bin/python#{python_major}-config --prefix`.chomp
       python_include=Dir["#{python_prefix}/include/*"].first
       python_library=Dir["#{python_prefix}/lib/libpython*" + (OS.mac? ? ".dylib" : ".so")].first
 
@@ -47,7 +49,7 @@ class MedFile < Formula
 
     mkdir "build" do
       system "cmake", "..", *cmake_args
-      system "make", "install"
+      system "make", "-j#{ENV.make_jobs}", "install"
     end
   end
 


### PR DESCRIPTION
Homebrew python-config is named python2-config
or python3-config.  This figures out the right one.

Also adds -j argument to make like a lot of formulas

This tap is not maintained. Please consider opening a pull request to migrate this formula to Homebrew/core or a different tap within the [Brewsci organization](https://github.com/brewsci). Please open an issue if you are interested in creating and maintaining a new tap within the Brewsci organization.

# Hosting Your Own Tap

Anyone can host their own tap. See [Interesting Taps & Forks](https://docs.brew.sh/Interesting-Taps-and-Forks.html) and [How to Create and Maintain a Tap](https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap.html)
