### PR TITLE
andi: Remove the bottle for Linux

### DIFF
--- a/Formula/andi.rb
+++ b/Formula/andi.rb
@@ -12,7 +12,6 @@ class Andi < Formula
     sha256 "c425a345402fa748a7b0db68ee7e64b2d29a5ab3eb9d255efeefb0bc19a4ece3" => :sierra
     sha256 "1948482416f7f91ece5e1e67a99ae2a278340a659d7068f7985a0817b5372634" => :el_capitan
     sha256 "146f7bd5d895fced30bf03c0ea3bd7674d2fcb5ac9aff11e0b0a2bd55965f65d" => :yosemite
-    sha256 "a0a7c09fc0d62dbf6959806a08b244d7fde9ed4853bc0e61c4b336fdee9774c8" => :x86_64_linux
   end
 
   depends_on "gsl"


### PR DESCRIPTION
This bottle does not exist on Bintray.
See https://bintray.com/linuxbrew/bottles-science/andi/#files