### PR TITLE
Remove :run from depends_on

### DIFF
--- a/Formula/dealii.rb
+++ b/Formula/dealii.rb
@@ -14,7 +14,7 @@ class Dealii < Formula
   deprecated_option "without-mpi" => "without-open-mpi"
   deprecated_option "without-opencascade" => "without-oce"
 
-  depends_on "cmake"        => :run
+  depends_on "cmake"
   depends_on "openmpi"      => :recommended
   depends_on "openblas"     => :optional
 

--- a/Formula/geant4.rb
+++ b/Formula/geant4.rb
@@ -18,7 +18,7 @@ class Geant4 < Formula
   option "with-usolids", "Use USolids (experimental)"
   option "without-multithreaded", "Build without multithreading support"
 
-  depends_on "cmake" => :run
+  depends_on "cmake"
   depends_on :x11
   depends_on "qt" => :optional
   depends_on "xerces-c" if build.with? "gdml"

--- a/Formula/ggobi.rb
+++ b/Formula/ggobi.rb
@@ -13,7 +13,7 @@ class Ggobi < Formula
   depends_on "pkg-config" => :build
   depends_on "gtk+"
   depends_on "gettext"
-  depends_on "libtool" => :run
+  depends_on "libtool"
 
   def install
     # Necessary for ggobi to build - based on patch from MacPorts

--- a/Formula/gnudatalanguage.rb
+++ b/Formula/gnudatalanguage.rb
@@ -26,7 +26,7 @@ class Gnudatalanguage < Formula
   depends_on "cairo"
   depends_on "pango"
   depends_on "freetype"
-  depends_on "libtool" => :run
+  depends_on "libtool"
 
   conflicts_with "plplot", :because => "both install a pltek executable"
 

--- a/Formula/libbi.rb
+++ b/Formula/libbi.rb
@@ -29,7 +29,7 @@ class Libbi < Formula
   depends_on "netcdf"
   depends_on "gsl"
   depends_on "boost"
-  depends_on "automake" => :run
+  depends_on "automake"
 
   resource "Test::Simple" do
     url "https://www.cpan.org/authors/id/E/EX/EXODIST/Test-Simple-1.302086.tar.gz"

--- a/Formula/mlpack.rb
+++ b/Formula/mlpack.rb
@@ -20,7 +20,7 @@ class Mlpack < Formula
   deprecated_option "with-check" => "with-test"
 
   depends_on "cmake" => :build
-  depends_on "pkg-config" => :run
+  depends_on "pkg-config"
   depends_on "armadillo"
   depends_on "boost"
   depends_on "libxml2"

--- a/Formula/nest.rb
+++ b/Formula/nest.rb
@@ -32,8 +32,8 @@ class Nest < Formula
   depends_on "scipy" => requires_py3
   depends_on "matplotlib" => requires_py3
 
-  depends_on "libtool" => :run
-  depends_on "readline" => :run
+  depends_on "libtool"
+  depends_on "readline"
   depends_on "cmake" => :build
 
   resource "Cython" do

--- a/Formula/pandaseq.rb
+++ b/Formula/pandaseq.rb
@@ -19,7 +19,7 @@ class Pandaseq < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "pkg-config" => :build
-  depends_on "libtool" => :run
+  depends_on "libtool"
   depends_on "zlib" unless OS.mac?
 
   def install

--- a/Formula/pocl.rb
+++ b/Formula/pocl.rb
@@ -15,7 +15,7 @@ class Pocl < Formula
   depends_on "pkg-config" => :build
   depends_on "llvm"
   depends_on "hwloc"
-  depends_on "libtool" => :run
+  depends_on "libtool"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/reapr.rb
+++ b/Formula/reapr.rb
@@ -16,8 +16,8 @@ class Reapr < Formula
 
   depends_on "bamtools"
   depends_on "htslib"
-  depends_on "r" => [:recommended, :run] # only needed for the test
   depends_on "smalt"
+  depends_on "r" => :test
 
   resource "manual" do
     url "ftp://ftp.sanger.ac.uk/pub/resources/software/reapr/Reapr_1.0.18.manual.pdf"


### PR DESCRIPTION
Calling `depends_on ... => :run` is deprecated.