### PR TITLE
ParaView: built in Linuxbrew and add options

### DIFF
--- a/Formula/paraview.rb
+++ b/Formula/paraview.rb
@@ -31,7 +31,7 @@ class Paraview < Formula
 
   def install
     # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j1" if ENV["CIRCLECI"]
+    ENV["MAKEFLAGS"] = "-j2" if ENV["CIRCLECI"]
     
     dylib = OS.mac? ? "dylib" : "so"
 

--- a/Formula/paraview.rb
+++ b/Formula/paraview.rb
@@ -3,7 +3,7 @@ class Paraview < Formula
   homepage "https://www.paraview.org/"
   url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v5.4&type=source&os=Sources&downloadFile=ParaView-v5.4.1.tar.gz"
   sha256 "390d0f5dc66bf432e202a39b1f34193af4bf8aad2355338fa5e2778ea07a80e4"
-  revision 4
+  revision 3
 
   head "https://gitlab.kitware.com/paraview/paraview.git"
   

--- a/Formula/paraview.rb
+++ b/Formula/paraview.rb
@@ -11,6 +11,7 @@ class Paraview < Formula
 
   depends_on "cmake" => :build
 
+  depends_on "expat"
   depends_on "fontconfig"
   depends_on "freetype"
   depends_on "glu" if OS.linux? && (build.without? "osmesa")
@@ -28,6 +29,9 @@ class Paraview < Formula
   depends_on "open-mpi" => :optional
 
   def install
+    # Reduce memory usage below 4 GB for Circle CI.
+    ENV["MAKEFLAGS"] = "-j2" if ENV["CIRCLECI"]
+    
     dylib = OS.mac? ? "dylib" : "so"
 
     args = std_cmake_args + %W[

--- a/Formula/paraview.rb
+++ b/Formula/paraview.rb
@@ -3,7 +3,7 @@ class Paraview < Formula
   homepage "https://www.paraview.org/"
   url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v5.4&type=source&os=Sources&downloadFile=ParaView-v5.4.1.tar.gz"
   sha256 "390d0f5dc66bf432e202a39b1f34193af4bf8aad2355338fa5e2778ea07a80e4"
-  revision 3
+  revision 1
 
   head "https://gitlab.kitware.com/paraview/paraview.git"
   

--- a/Formula/paraview.rb
+++ b/Formula/paraview.rb
@@ -1,30 +1,31 @@
 class Paraview < Formula
   desc "Multi-platform data analysis and visualization application"
   homepage "https://www.paraview.org/"
-  url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v5.3&type=source&os=all&downloadFile=ParaView-v5.3.0.tar.gz"
-  sha256 "046631bbf00775edc927314a3db207509666c9c6aadc7079e5159440fd2f88a0"
-  revision 3
+  url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v5.4&type=source&os=Sources&downloadFile=ParaView-v5.4.1.tar.gz"
+  sha256 "390d0f5dc66bf432e202a39b1f34193af4bf8aad2355338fa5e2778ea07a80e4"
+  revision 4
 
   head "https://gitlab.kitware.com/paraview/paraview.git"
 
-  bottle :disable, "needs to be rebuilt with latest boost"
-
-  deprecated_option "with-mpi" => "with-open-mpi"
+  option "with-osmesa", "Build with off-sceen mesa(osmesa)"
 
   depends_on "cmake" => :build
 
-  depends_on "boost" => :recommended
-  depends_on "ffmpeg" => :recommended
-  depends_on "qt" => :recommended
-  depends_on "open-mpi" => :optional
-  depends_on "python" => :recommended
-
+  depends_on "fontconfig"
   depends_on "freetype"
+  depends_on "glu" if OS.linux? && (build.without? "osmesa")
   depends_on "hdf5"
   depends_on "jpeg"
-  depends_on "libtiff"
-  depends_on "fontconfig"
   depends_on "libpng"
+  depends_on "libtiff"
+  depends_on "mesa" if OS.linux?
+
+  depends_on "boost" => :recommended
+  depends_on "ffmpeg" => :recommended
+  depends_on "python" => :recommended
+  depends_on "qt" => :recommended
+  depends_on "mpich" => :optional
+  depends_on "open-mpi" => :optional
 
   def install
     dylib = OS.mac? ? "dylib" : "so"
@@ -46,16 +47,30 @@ class Paraview < Formula
       -DVTK_USE_SYSTEM_ZLIB:BOOL=NETCDF
     ]
 
+    if build.with? "osmesa"
+      args = std_cmake_args + %W[
+        -DVTK_USE_X=OFF
+        -DOPENGL_INCLUDE_DIR=IGNORE
+        -DOPENGL_xmesa_INCLUDE_DIR=IGNORE
+        -DOPENGL_gl_LIBRARY=IGNORE
+        -DOSMESA_INCLUDE_DIR=#{Formula["mesa"].opt_include}
+        -DOSMESA_LIBRARY=#{Formula["mesa"].opt_lib}/libOSMesa.so
+        -DVTK_OPENGL_HAS_OSMESA=ON
+        -DVTK_USE_OFFSCREEN=OFF
+      ]
+    end
+ 
     args << "-DPARAVIEW_BUILD_QT_GUI:BOOL=OFF" if build.without? "qt"
     args << "-DPARAVIEW_USE_MPI:BOOL=ON" if build.with? "open-mpi"
+    args << "-DPARAVIEW_USE_MPI:BOOL=ON" if build.with? "mpich"
     args << "-DPARAVIEW_ENABLE_FFMPEG:BOOL=ON" if build.with? "ffmpeg"
     args << "-DPARAVIEW_USE_VISITBRIDGE:BOOL=ON" if build.with? "boost"
-    args << "-DPARAVIEW_ENABLE_PYTHON:BOOL=" + ((build.with? "python") ? "ON" : "OFF")
+    args << "-DPARAVIEW_ENABLE_PYTHON:BOOL=" + (build.with?("python") ? "ON" : "OFF")
 
     mkdir "build" do
       # Python3 support is being worked on, see https://gitlab.kitware.com/paraview/paraview/issues/16818
       if build.with? "python"
-        python_executable = `which python`.strip
+        python_executable = Formula["python@2"].opt_bin/"python2"
         python_prefix = `#{python_executable} -c 'import sys;print(sys.prefix)'`.chomp
         python_include = `#{python_executable} -c 'from distutils import sysconfig;print(sysconfig.get_python_inc(True))'`.chomp
         python_version = "python" + `#{python_executable} -c 'import sys;print(sys.version[:3])'`.chomp

--- a/Formula/paraview.rb
+++ b/Formula/paraview.rb
@@ -6,6 +6,8 @@ class Paraview < Formula
   revision 4
 
   head "https://gitlab.kitware.com/paraview/paraview.git"
+  
+  bottle :disable, "needs to be rebuilt with latest boost"
 
   option "with-osmesa", "Build with off-sceen mesa(osmesa)"
 

--- a/Formula/paraview.rb
+++ b/Formula/paraview.rb
@@ -13,7 +13,6 @@ class Paraview < Formula
 
   depends_on "cmake" => :build
 
-  depends_on "expat"
   depends_on "fontconfig"
   depends_on "freetype"
   depends_on "glu" if OS.linux? && (build.without? "osmesa")
@@ -32,7 +31,7 @@ class Paraview < Formula
 
   def install
     # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j2" if ENV["CIRCLECI"]
+    ENV["MAKEFLAGS"] = "-j1" if ENV["CIRCLECI"]
     
     dylib = OS.mac? ? "dylib" : "so"
 


### PR DESCRIPTION
When I tried to submit `paraview.rb` to `Linuxbrew/homebrew-core`, I was recommended to submit to 
`brewsci/homebrew-science` [https://github.com/Linuxbrew/homebrew-core/pull/8443#issuecomment-407808397](https://github.com/Linuxbrew/homebrew-core/pull/8443#issuecomment-407808397).

1. version up to 5.4.1
2. build in linux
3. add option "osmesa"
4. add option "mpich"
