### PR TITLE
add xcrysden

### DIFF
--- a/Formula/tcl-tk-x11.rb
+++ b/Formula/tcl-tk-x11.rb
@@ -1,0 +1,103 @@
+class TclTkX11 < Formula
+  desc "Tool Command Language"
+  homepage "https://www.tcl.tk/"
+
+  stable do
+    url "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.8/tcl8.6.8-src.tar.gz"
+    mirror "ftp://ftp.tcl.tk/pub/tcl/tcl8_6/tcl8.6.8-src.tar.gz"
+    version "8.6.8"
+    sha256 "c43cb0c1518ce42b00e7c8f6eaddd5195c53a98f94adc717234a65cbcfd3f96a"
+
+    resource "tk" do
+      url "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.8/tk8.6.8-src.tar.gz"
+      mirror "ftp://ftp.tcl.tk/pub/tcl/tcl8_6/tk8.6.8-src.tar.gz"
+      version "8.6.8"
+      sha256 "49e7bca08dde95195a27f594f7c850b088be357a7c7096e44e1158c7a5fd7b33"
+
+      # Upstream issue 7 Jan 2018 "Build failure with Aqua support on OS X 10.8 and 10.9"
+      # See https://core.tcl.tk/tcl/tktview/95a8293a2936e34cc8d0658c21e5214f1ca9b435
+      if MacOS.version == :mavericks || MacOS.version == :mountain_lion
+        patch :p0 do
+          url "https://raw.githubusercontent.com/macports/macports-ports/0a883ad388b/x11/tk/files/patch-macosx-tkMacOSXXStubs.c.diff"
+          sha256 "943241a5bc07e8a638cb09d7ee6e4ffb3705e567d7a7c411b2d5aebb9ce6c285"
+        end
+      end
+    end
+  end
+
+  # bottle do
+  #   sha256 "cd4dec2b564dcad86b151803c852142366bc48ec1b13d48a2e495c83fc32a688" => :high_sierra
+  #   sha256 "96144fc3d7eaeec6125ff9f534f0aa21b61b673914dd8cb4898b10ca0530d90e" => :sierra
+  #   sha256 "79222749d221013eb7d1fb529ace13293a819b43d6633b964d1f8f318ac66f33" => :el_capitan
+  # end
+
+  devel do
+    url "https://downloads.sourceforge.net/project/tcl/Tcl/8.7a1/tcl8.7a1-src.tar.gz"
+    mirror "ftp://ftp.tcl.tk/pub/tcl/tcl8_7/tk8.7a1-src.tar.gz"
+    version "8.7a1"
+    sha256 "2bbd4e0bbdebeaf5dc6cc823d0805afb45c764292f6667d9ce2b9fcf5399e0dc"
+
+    resource "tk" do
+      url "https://downloads.sourceforge.net/project/tcl/Tcl/8.7a1/tk8.7a1-src.tar.gz"
+      mirror "ftp://ftp.tcl.tk/pub/tcl/tcl8_7/tk8.7a1-src.tar.gz"
+      sha256 "131e4bae43a15dff0324c0479358bb42cfd7b8de0e1ca8d93c9207643c7144dd"
+    end
+  end
+
+  keg_only :provided_by_macos,
+    "tk installs some X11 headers and macOS provides an (older) Tcl/Tk"
+
+  option "without-tcllib", "Don't build tcllib (utility modules)"
+  option "without-tk", "Don't build the Tk (window toolkit)"
+
+  depends_on :x11
+  depends_on "pkg-config"
+
+  resource "tcllib" do
+    url "https://downloads.sourceforge.net/project/tcllib/tcllib/1.18/tcllib-1.18.tar.gz"
+    sha256 "72667ecbbd41af740157ee346db77734d1245b41dffc13ac80ca678dd3ccb515"
+  end
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      --mandir=#{man}
+      --enable-threads
+      --enable-64bit
+    ]
+
+    cd "unix" do
+      system "./configure", *args
+      system "make"
+      system "make", "install"
+      system "make", "install-private-headers"
+      ln_s bin/"tclsh#{version.to_f}", bin/"tclsh"
+    end
+
+    if build.with? "tk"
+      ENV.prepend_path "PATH", bin # so that tk finds our new tclsh
+
+      resource("tk").stage do
+        cd "unix" do
+          system "./configure", *args, "--with-x", "--with-tcl=#{lib}"
+          system "make"
+          system "make", "install"
+          system "make", "install-private-headers"
+          ln_s bin/"wish#{version.to_f}", bin/"wish"
+        end
+      end
+    end
+
+    if build.with? "tcllib"
+      resource("tcllib").stage do
+        system "./configure", "--prefix=#{prefix}",
+                              "--mandir=#{man}"
+        system "make", "install"
+      end
+    end
+  end
+
+  test do
+    assert_equal "honk", pipe_output("#{bin}/tclsh", "puts honk\n").chomp
+  end
+end

--- a/Formula/xcrysden.rb
+++ b/Formula/xcrysden.rb
@@ -1,0 +1,46 @@
+class Xcrysden < Formula
+  desc "Crystalline and molecular structure visualisation program"
+  homepage "http://www.xcrysden.org/"
+  url "http://www.xcrysden.org/download/xcrysden-1.5.60.tar.gz"
+  sha256 "a695729f1bb3e486b86a74106c06a392c8aca048dc6b0f20785c3c311cfb2ef4"
+
+  depends_on :x11
+  depends_on "gcc"
+  depends_on "tcl-tk" => "with-x11"
+  depends_on "fftw"
+  depends_on "wget" => :build
+
+  # Fix togl -accum false in Tcl and modify Make.sys
+  patch do
+    url "https://gist.githubusercontent.com/specter119/4f630e538d39edcf67ec742f78c23aab/raw/ff73b6838cc2efd8c4fac3608e1a3f63355382a9/xcrysden-homebrew.patch"
+    sha256 "ad55c57702345a0cfd99364bd7e9dc8982f002409537ef173040bc67ef67dda1"
+  end
+
+  def install
+    cp "system/Make.macosx-x11", "Make.sys"
+
+    ENV.deparallelize
+    system "make", "xcrysden"
+
+    args = %W[
+      prefix=#{prefix}
+    ]
+
+    system "make", *args, "install"
+  end
+
+  def caveats
+    <<~EOS
+      XCrySDen can be user-customized. Create $HOME/.xcrysden/ directory
+      and copy the "custom-definitions" and "Xcrysden_resources" files
+      from the Tcl/ subdirectory of the XCrySDen root directory.
+      These can be then modified according to user preference.
+
+      For more info about customization, see: http://www.xcrysden.org/doc/custom.html
+    EOS
+  end
+
+  test do
+    system bin/"xcrysden", "--version"
+  end
+end

--- a/Formula/xcrysden.rb
+++ b/Formula/xcrysden.rb
@@ -5,15 +5,15 @@ class Xcrysden < Formula
   sha256 "a695729f1bb3e486b86a74106c06a392c8aca048dc6b0f20785c3c311cfb2ef4"
 
   depends_on "gcc"
-  depends_on "tcl-tk" => "with-x11"
+  depends_on "tcl-tk-x11"
   depends_on "fftw"
   depends_on "wget" => :build
   depends_on :x11
 
   # Fix togl -accum false in Tcl and modify Make.sys
   patch do
-    url "https://gist.githubusercontent.com/specter119/4f630e538d39edcf67ec742f78c23aab/raw/ff73b6838cc2efd8c4fac3608e1a3f63355382a9/xcrysden-homebrew.patch"
-    sha256 "ad55c57702345a0cfd99364bd7e9dc8982f002409537ef173040bc67ef67dda1"
+    url "https://gist.githubusercontent.com/specter119/4f630e538d39edcf67ec742f78c23aab/raw/464f0a813f209df5bd008b3ef4b2394e86117439/xcrysden-homebrew.patch"
+    sha256 "943241a5bc07e8a638cb09d7ee6e4ffb3705e567d7a7c411b2d5aebb9ce6c285"
   end
 
   def install

--- a/Formula/xcrysden.rb
+++ b/Formula/xcrysden.rb
@@ -4,11 +4,11 @@ class Xcrysden < Formula
   url "http://www.xcrysden.org/download/xcrysden-1.5.60.tar.gz"
   sha256 "a695729f1bb3e486b86a74106c06a392c8aca048dc6b0f20785c3c311cfb2ef4"
 
-  depends_on :x11
   depends_on "gcc"
   depends_on "tcl-tk" => "with-x11"
   depends_on "fftw"
   depends_on "wget" => :build
+  depends_on :x11
 
   # Fix togl -accum false in Tcl and modify Make.sys
   patch do


### PR DESCRIPTION
This tap is not maintained. Please consider opening a pull request to migrate this formula to Homebrew/core or a different tap within the [Brewsci organization](https://github.com/brewsci). Please open an issue if you are interested in creating and maintaining a new tap within the Brewsci organization.

# Hosting Your Own Tap

Anyone can host their own tap. See [Interesting Taps & Forks](https://docs.brew.sh/Interesting-Taps-and-Forks.html) and [How to Create and Maintain a Tap](https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap.html)

xcrysden will work after [add with-x11 option for tcl-tk \@homebrew-core](https://github.com/Homebrew/homebrew-core/pull/30756) merged.