### PR TITLE
Update and migrate phylip

### DIFF
--- a/Formula/phylip.rb
+++ b/Formula/phylip.rb
@@ -4,7 +4,7 @@ class Phylip < Formula
   # tag "bioinformatics"
   # doi "10.1007/BF01734359"
 
-  url "http://evolution.gs.washington.edu/phylip/download/phylip-3.696.tar.gz"
+  url "http://evolution.gs.washington.edu/phylip/download/phylip-3.697.tar.gz"
   sha256 "cd0a452ca51922142ad06d585e2ef98565536a227cbd2bd47a2243af72c84a06"
 
   bottle do


### PR DESCRIPTION
Changed URL to "http://evolution.gs.washington.edu/phylip/download/phylip-3.697.tar.gz"
Requesting to migrate formula to Brewsci/bio.

*****

This tap is not maintained. Please consider opening a pull request to migrate this formula to Homebrew/core or a different tap within the [Brewsci organization](https://github.com/brewsci). Please open an issue if you are interested in creating and maintaining a new tap within the Brewsci organization.

# Hosting Your Own Tap

Anyone can host their own tap. See [Interesting Taps & Forks](https://docs.brew.sh/Interesting-Taps-and-Forks.html) and [How to Create and Maintain a Tap](https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap.html)
