### PR TITLE
Update and migrate trinity

### DIFF
--- a/Formula/trinity.rb
+++ b/Formula/trinity.rb
@@ -1,7 +1,7 @@
 class Trinity < Formula
   desc "RNA-Seq de novo assembler"
   homepage "https://trinityrnaseq.github.io"
-  url "https://github.com/trinityrnaseq/trinityrnaseq/archive/Trinity-v2.5.1.tar.gz"
+  url "https://github.com/trinityrnaseq/trinityrnaseq/archive/Trinity-v2.8.3.tar.gz"
   sha256 "bf14f96981bb028d7960dec895a1bcbda1fadbbe562a913b188559fd74b90457"
   head "https://github.com/trinityrnaseq/trinityrnaseq.git"
 


### PR DESCRIPTION
Changed URL to "https://github.com/trinityrnaseq/trinityrnaseq/archive/Trinity-v2.8.3.tar.gz"
Requesting to migrate formula to brewsci/bio.

This tap is not maintained. Please consider opening a pull request to migrate this formula to Homebrew/core or a different tap within the [Brewsci organization](https://github.com/brewsci). Please open an issue if you are interested in creating and maintaining a new tap within the Brewsci organization.

# Hosting Your Own Tap

Anyone can host their own tap. See [Interesting Taps & Forks](https://docs.brew.sh/Interesting-Taps-and-Forks.html) and [How to Create and Maintain a Tap](https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap.html)
