### PR TITLE
Update concorde.rb

### DIFF
--- a/Formula/concorde.rb
+++ b/Formula/concorde.rb
@@ -25,7 +25,7 @@ class Concorde < Formula
       mkdir "cplex_files"
       cd "cplex_files" do
         ln_s Dir["#{cplex_path}/include/ilcplex/*.h"], "."
-        if MacOS.prefer_64_bit?
+        if MacOS.is_64_bit?
           ln_s "#{cplex_path}/lib/x86-64_osx/static_pic/libcplex.a", "."
         else
           ln_s "#{cplex_path}/lib/x86-32_osx/static_pic/libcplex.a", "."


### PR DESCRIPTION
MacOS.is_64_bit? Should be used instead of the deprecated function

This tap is not maintained. Please consider opening a pull request to migrate this formula to Homebrew/core or a different tap within the [Brewsci organization](https://github.com/brewsci). Please open an issue if you are interested in creating and maintaining a new tap within the Brewsci organization.

# Hosting Your Own Tap

Anyone can host their own tap. See [Interesting Taps & Forks](https://docs.brew.sh/Interesting-Taps-and-Forks.html) and [How to Create and Maintain a Tap](https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap.html)
